### PR TITLE
Make the AWS region be capable to pass to the CFn command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SERVICE := src
 AWS_PROFILE=default
 SERVICE_NAME=certupdater
 BUCKET_NAME=example-$(SERVICE_NAME)-artifacts
-CFN_CMD=aws --profile $(AWS_PROFILE) cloudformation
+CFN_CMD=aws --profile $(AWS_PROFILE) $$(if [ -n "$(AWS_REGION)" ]; then echo "--region $(AWS_REGION)"; fi) cloudformation
 TMP_TEMPLATE=tmp_template.yml
 STACK_NAME=$(SERVICE_NAME)-stack
 


### PR DESCRIPTION
if the `AWS_REGION` parameter is specified.