### PR TITLE
Make log level be specifiable through JSON configuration

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -48,7 +48,11 @@ schema = {
                     'type': 'string'
                 }
             }
-        }
+        },
+        'log_level': {
+            "type": "string",
+            "enum": ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"],
+        },
     }
 }
 
@@ -180,6 +184,12 @@ def handler(event, context):
     try:
 
         jsonschema.validate(event, schema)
+
+        log_level = event.get('log_level')
+        if log_level:
+            level = logging.getLevelName(log_level)
+            for name in logging.Logger.manager.loggerDict.keys():
+                logging.getLogger(name).setLevel(level)
 
         domains = event.get('domains')
         is_production = event.get('is_production')

--- a/src/main.py
+++ b/src/main.py
@@ -52,7 +52,14 @@ schema = {
         },
         'log_level': {
             "type": "string",
-            "enum": ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"],
+            "enum": [
+                "CRITICAL",
+                "ERROR",
+                "WARNING",
+                "INFO",
+                "DEBUG",
+                "NOTSET",
+            ]
         },
     }
 }

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import boto3
 import certbot.main
+import logging
 import os
 import shutil
 import json


### PR DESCRIPTION
This is **just a proposal** for this subject.

Now, the log output is verbose because the default log level is set as `DEBUG`.
This pull-request tries to specify the log level to make the logging be suitable for the demand of users.

What do you think about this?