### PR TITLE
Upgrade the Lambda python runtime to 3.9

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: CertUpdater
- 
+
 Resources:
   CertUpdater:
     Type: AWS::Serverless::Function
@@ -9,7 +9,7 @@ Resources:
       FunctionName: CertUpdater
       CodeUri: src
       Handler: main.handler
-      Runtime: python3.6
+      Runtime: python3.9
       AutoPublishAlias: live
       Timeout: 240
       MemorySize: 128


### PR DESCRIPTION
Due to the python 3.6 EOL on the Lambda on July 18, 2022.
see also: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy